### PR TITLE
fix: replace "Value" with "Host" in "hostString"

### DIFF
--- a/src/Localtunnel.Server/Dns/BasicTunnelDnsProvider.cs
+++ b/src/Localtunnel.Server/Dns/BasicTunnelDnsProvider.cs
@@ -47,7 +47,7 @@ internal sealed class BasicTunnelDnsProvider : ITunnelDnsProvider
     /// <inheritdoc/>
     public bool TryGetTunnel(HostString hostString, string? subdomainName, out TunnelId tunnelId)
     {
-        if (!hostString.Value.Equals(_zone, StringComparison.OrdinalIgnoreCase))
+        if (!hostString.Host.Equals(_zone, StringComparison.OrdinalIgnoreCase))
         {
             tunnelId = default;
             return false;

--- a/src/Localtunnel.Server/TunnelInformation.cs
+++ b/src/Localtunnel.Server/TunnelInformation.cs
@@ -69,7 +69,7 @@ internal sealed class TunnelInformation : IDisposable
 
         var targetRequestUri = new UriBuilder(
             scheme: Uri.UriSchemeHttp,
-            host: httpRequest.Host.Value,
+            host: httpRequest.Host.Host,
             port: httpRequest.Host.Port.GetValueOrDefault(80),
             pathValue: httpRequest.Path.Value);
 


### PR DESCRIPTION
I replaced "Value" with "Host" in "hostString". Using "Value" includes the port number (when not using port 80 or 443) which might lead to unwanted behavior.